### PR TITLE
Adjust Exit Action implementation to allow Ctrl-click and Shift-click.

### DIFF
--- a/script/train.lua
+++ b/script/train.lua
@@ -88,15 +88,12 @@ function sendPickupTrain(train, player, destination)
     {{ type = "passenger_not_present", compare_type = "and" },
      { type = "time", compare_type = "and", ticks = 7200 }}))
 
-  -- Finally, if the player has the appropriate option enabled,
+  -- Finally, if the player has a depot name set,
   -- then a record is added to return the train to the depot
-  local exitAction = exitActionOf(player)
-  if exitAction == "Depot" then
-    local depotName = depotNameOf(player)
-    if depotName ~= "" then
-      table.insert(recs, { station = depotName, wait_conditions =
-        {{ type = "circuit", compare_type = "and" }}})
-    end
+  local depotName = depotNameOf(player)
+  if depotName ~= "" then
+    table.insert(recs, { station = depotName, wait_conditions =
+      {{ type = "circuit", compare_type = "and" }}})
   end
 
   train.schedule = {
@@ -150,25 +147,7 @@ function transportTo(train, player, destination)
   log("transport via shuttle train "..train.front_stock.backer_name.." to "..destination.backer_name.." for "..player.name)
   train.manual_mode = true
 
-  local exitAction = exitActionOf(player)
-  local depotName
-
-  if exitAction == "Depot" then
-    depotName = depotNameOf(player)
-  end
-
-  if exitAction == "Depot" and depotName ~= "" then
-    train.schedule = { current = 1, records = {
-      {rail = destination.connected_rail, temporary = true, wait_conditions = {
-        {type = "passenger_not_present", compare_type = "and"}}},
-      {station = destination.backer_name, wait_conditions = {
-        {type = "passenger_not_present", compare_type = "and"},
-        {type = "time", compare_type = "and", ticks = 180}}},
-      {station = depotName, wait_conditions = {{type = "circuit", compare_type = "and"}}}
-    }}
-  else
-    train.schedule = { current = 1, records = {{station = destination.backer_name}}}
-  end
+  train.schedule = { current = 1, records = {{station = destination.backer_name}}}
 
   train.manual_mode = false
   trackTrain(train, player, destination, STATUS_TRANSPORT)
@@ -201,9 +180,6 @@ function onTrackedTrainChangedStatus(train)
   if status == defines.train_state.wait_station then
     if train.station and train.station.backer_name == track.destinationName then
       untrackTrain(train)
-      if track.status == STATUS_TRANSPORT and exitActionOf(track.player) == "Manual" then
-        train.manual_mode = true
-      end
     end
   elseif status == defines.train_state.no_path or status == defines.train_state.path_lost then
     untrackTrain(train)


### PR DESCRIPTION
I think that this patch may require some discussion, in case there is a better/prefered way to accomplish this -- I'm definitely willing to re-work it with a different approach if needed.

My goal was to make the existing "Exit Action" feature continue to work as expected, even if a player ignores the destination-selection dialog (by either ctrl-clicking on a rail, or shift-clicking on a train stop).

In the current version of the mod, the following situations may occur after entering a shuttle:
- The player selects a destination via the mod's dialog
  - In this case, everything works as expected
- The player opens the map and ctrl-clicks on a rail
  - The shuttle will go to the requested rail, but it will depart after 5 seconds (regardless of whether the player is still inside)
  - Also, the shuttle will return to the location where a pickup was requested, instead of the depot
- The player opens the map and shift-clicks on a train stop
  - Since shift-clicking adds a train stop to the end of the current schedule, the shuttle will not move at all

With my patch, all of the above situations are handled properly: the shuttle will travel to the requested train stop or rail, and take the configured exit action after the player has left the shuttle.
- Automatic: After 2 minutes with no passanger, return to the depot
- Manual: Stay in place and switch to manual mode
- Depot: Immediately return to the depot

This patch accomplishes in two parts:
1. In order to allow players to easily control the shuttle via ctrl/shift-clicking, the shuttle's current schedule is cleared when the first player enters it.
2. Since (1) breaks the existing Exit Action implementation, it is also necessary to restore the schedule once the last player leaves a shuttle

The biggest changes were made to "onPlayerDrivingChangedState(event)", which is now wholely responsible for Exit Actions. I also added a helper function "getNextRailForTrain(train)" (currently only used by onPlayerDrivingChangedState(event)), but I'm not sure whether or not it should be moved to another file. Perhaps utils.lua would make more sense?

The relevant Exit Action logic was also removed from the following functions, since that is now handled elsewhere:
- transportTo(train, player, destination)
  - No longer includes logic to add an extra schedule entry for the depot
- onTrackedTrainChangedStatus(train)
  - No longer includes logic to set the shuttle to manual mode
- sendPickupTrain(train, player, destination)
  - Now adds a schedule entry to return the shuttle to the depot, regardless of the player's exit action (so long as a depot name exists)
