### PR TITLE
Allow players to use their personal map (the "M" hotkey) with the Smart Destination feature.

### DIFF
--- a/script/events.lua
+++ b/script/events.lua
@@ -24,6 +24,9 @@ local function onPlayerDrivingChangedState(event)
   if player.vehicle then
     if controlsShuttleTrain(player) then
       log("player "..player.name.." entered shuttle train "..player.vehicle.train.front_stock.backer_name)
+      local records = (event.entity.train.schedule or {}).records or {}
+      log("Storing shuttle train schedule for player "..player.name)
+      global.playerTrain[event.player_index] = {id = event.entity.train.id, schedule = copyTrainScheduleRecordTargets(records)}
       openDialog(player)
     end
   else
@@ -160,9 +163,6 @@ function onGuiOpened(event)
   if event.gui_type == defines.gui_type.entity then
     local player = game.players[event.player_index]
     if player and event.entity.train and isShuttleTrain(event.entity.train) then
-      local records = (event.entity.train.schedule or {}).records or {}
-      log("Storing shuttle train schedule for player "..player.name)
-      global.playerTrain[event.player_index] = {id = event.entity.train.id, schedule = copyTrainScheduleRecordTargets(records)}
       if player.vehicle and player.vehicle.train == event.entity.train then
         closeDialog(player)
       end


### PR DESCRIPTION
The current Smart Destination implementation only saves the shuttle's schedule when a train's GUI is opened. As a result, if a player opens their personal map (without opening the train's GUI), then Shift/Ctrl-clicking will not trigger the smart logic; the shuttle behaves as if the "Smart manual destination selection" option is disabled.

This match simply moves the code to save the shuttle's schedule from from onGuiOpened() to onPlayerDrivingChangedState(), so that playerChangedTrainSchedule() can determine how the train's schedule has changed even before the GUI is opened.