### PR TITLE
Modal destination station selection dialog

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -163,8 +163,5 @@ function playerChangedTrainSchedule(player, train)
 
   log("destination "..tostring(dest))
   transportTo(train, player, dest)
-  if player.opened then
-    player.opened = nil
-  end
 end
 

--- a/script/dialog.lua
+++ b/script/dialog.lua
@@ -18,8 +18,6 @@ function toggleDialog(player)
   else
     openDialog(player)
   end
-
-  player.opened = visible and dialog or nil
 end
 
 
@@ -30,9 +28,15 @@ end
 -- 
 function closeDialog(player)
   local dialog = player.gui.screen[DIALOG_NAME]
+
   if dialog then
     dialog.visible = false
+
+    if player.opened == dialog then
+      player.opened = nil
+    end
   end
+
 end
 
 
@@ -101,6 +105,7 @@ function openDialog(player)
   dialog.style.maximal_height = 90 + guiHeight * 32;
 
   dialog.visible = true
+  player.opened = dialog
 
   if settings.get_player_settings(player)["shuttle-train-focus-search"].value then
     searchField.focus()

--- a/script/events.lua
+++ b/script/events.lua
@@ -186,10 +186,15 @@ end
 --        tile_position :: TilePosition (optional): The tile position that was open
 --
 function onGuiClosed(event)
-  if event.gui_type == defines.gui_type.entity and event.player_index and event.entity.train then
-      log("Clearing shuttle train schedule of player "..game.players[event.player_index].name)
-    global.playerTrain[event.player_index] = nil
+  local player = game.players[event.player_index]
+
+  if event.gui_type == defines.gui_type.entity and event.entity.train then
+    log("Clearing shuttle train schedule of player " .. player.name)
+    global.playerTrain[player.index] = nil
+  elseif event.gui_type == defines.gui_type.custom and event.element.name == "shuttleTrainDialog" then
+    closeDialog(player)
   end
+
 end
 
 


### PR DESCRIPTION
The purpose of this pull request is to make the destination selection dialog behave as a modal dialog. This makes the dialog less intrusive, and easier to dismiss by the player when opened by accident.

It is especially helpful to be able to dismiss the dialog when the auto-focus option is on. With that option, if entering the train by accident, it is not possible to simply leave the train by pressing enter - you must first click elsewhere on the screen so that the dialog loses the focus, and then press enter. On the other hand, being able to use `Escape` or `e` to close the dialog is quite consistent with how the rest of the game GUI behaves.