### PR TITLE
Fix compatibility with Automatic Train Painter equipment grids

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.7
+Date: 2022-07-07
+  Bugfix:
+    - Fix issue with shuttle train module not being usable with locomotive equipment grid from
+      Automatic Train Painter mod.
+---------------------------------------------------------------------------------------------------
 Version: 1.1.6
 Date: 2022-06-14
   Bugfix:

--- a/info.json
+++ b/info.json
@@ -10,7 +10,9 @@
   "dependencies": [
     "base >= 0.18.0",
     "(?) cargo-ships",
-    "(?) rz-K2PersonalTweaks"
+    "(?) rz-K2PersonalTweaks",
+    "(?) FARL",
+    "(?) Automatic_Train_Painter"
    ]
 }
 


### PR DESCRIPTION
The purpose of this pull request is to fix compatibility with the equipment grids from the Automatic Train Painter mod.

The underlying issue is that Shuttle Train Refresh code could get executed ahead of code from Automatic Train Painter mod in case where an additional optional dependency of that mod is installed as well, resulting in the locomotive equipment grid not accepting the equipment from Shuttle Train Refresh.